### PR TITLE
Fix clean-check package type resolution

### DIFF
--- a/packages/backend-common/package.json
+++ b/packages/backend-common/package.json
@@ -10,7 +10,10 @@
   "type": "module",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./dist/index.mjs",
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./dist/index.mjs"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -10,7 +10,10 @@
   "type": "module",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./dist/index.mjs",
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./dist/index.mjs"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -10,7 +10,10 @@
   "type": "module",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./dist/index.mjs",
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./dist/index.mjs"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- export shared workspace package types through package exports so fresh check runs can resolve @firapps/foundation, @firapps/backend-common, and @firapps/db without prebuilt dist artifacts
- restore truthful CI behavior for vp check on clean GitHub runners

## Verification
- vp check
- temp-copy clean-state proof: rsync current tree without dist/.output/node_modules to /tmp, run vp install --frozen-lockfile, then vp check successfully
- issue reproduced from the failed CI verify job on main merge commit and fixed at the package export layer