### PR TITLE
Fix publish workflow toolchain setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
       FIROPS_REPOSITORY_DISPATCH_TOKEN: ${{ secrets.FIROPS_REPOSITORY_DISPATCH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: "24"
+          cache: true
+      - run: vp install --frozen-lockfile
 
       - uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## Summary\n- install vp in the publish job before the drizzle generation guard\n- keep the GHCR publish and downstream dispatch path intact\n- restore a green main publish workflow instead of failing after image publication\n\n## Verification\n- vp check\n- GitHub Actions run 24753318503 failure analysis showed the missing toolchain setup\n