### PR TITLE
firapps MVP run: Open MVP draft PR after zot tag fix

### DIFF
--- a/.firapps/runs/7b726797-bbd9-463d-89b5-70cb12a8f82d.md
+++ b/.firapps/runs/7b726797-bbd9-463d-89b5-70cb12a8f82d.md
@@ -1,0 +1,19 @@
+# firapps MVP run report
+
+- Run ID: `7b726797-bbd9-463d-89b5-70cb12a8f82d`
+- Project: firapps MVP Project
+- Repository: firatoezcan/firapps
+- Requested by: Dispatch Bridge <dispatch-bridge@firapps.local>
+
+## Objective
+
+Create the first local-first draft pull request artifact for the firapps MVP happy path after switching to an explicit local zot-backed image tag and local cluster egress fixes.
+
+## Result summary
+
+Run accepted. The isolated devbox is provisioning.
+
+## Notes
+
+- This branch and PR were created by the local-first firapps MVP happy path.
+- The run report file is the first review artifact while deeper unattended code-edit automation continues to expand.


### PR DESCRIPTION
## firapps local-first SaaS MVP

This draft PR was opened automatically from a dispatched run.

- Run ID: `7b726797-bbd9-463d-89b5-70cb12a8f82d`
- Project: firapps MVP Project
- Objective: Create the first local-first draft pull request artifact for the firapps MVP happy path after switching to an explicit local zot-backed image tag and local cluster egress fixes.

The branch currently contains the generated run report artifact under `.firapps/runs/`.